### PR TITLE
Changed style-related methods

### DIFF
--- a/extensions/helper/Assets.php
+++ b/extensions/helper/Assets.php
@@ -8,22 +8,48 @@ class Assets extends \lithium\template\Helper {
 
 	/**
 	 * Takes a manifest name and:
-	 * 1. Compiles less files to css.
-	 * 2. Merges all files in the manifest (if $config['mergeAssets'] is true).
-	 * 3. Splits files by IE selector count limint (if $config['blessCss'] is true).
-	 * 4. Returns one or more style link tags.
+	 * 1. Generates the corresponding CSS files based on rules of $this->gen_css_files
+	 * 2. Returns one or more style link tags.
 	 *
 	 * @param  string $manifest name of manifest
 	 * @return string stylesheet `<link>` tag(s)
 	 */
 	public function style($manifest) {
-		$manifest = Manifest::load('css', $manifest);
-		$files = $manifest->build();
+		$files = $this->gen_css_files($manifest);
 		$tags = array();
 		foreach ($files as $file) {
 			$tags[] = $this->_context->helper('html')->style($file);
 		}
 		return implode("\n", $tags);
+	}
+
+	/**
+	 * Takes a manifest name and:
+	 * 1. Generates the corresponding CSS files based on rules of $this->gen_css_files
+	 * 2. Returns array of CSS files.
+	 *
+	 * @param  string $manifest name of manifest
+	 * @return array stylesheet files
+	 */
+	public function style_list($manifest) {
+		$files = $this->gen_css_files($manifest);
+		return $files;
+	}
+
+	/**
+	 * Takes a manifest name and:
+	 * 1. Compiles less files to css.
+	 * 2. Merges all files in the manifest (if $config['mergeAssets'] is true).
+	 * 3. Splits files by IE selector count limint (if $config['blessCss'] is true).
+	 * 4. Returns array of CSS files
+	 *
+	 * @param  string $manifest name of manifest
+	 * @return array stylesheet files
+	 */
+	private function gen_css_files($manifest) {
+		$manifest = Manifest::load('css', $manifest);
+		$files = $manifest->build();
+		return $files;
 	}
 
 	/**


### PR DESCRIPTION
Changed `Assets.php`, providing more flexibility around getting a manifest's styles. Previously one could only get a string of `<link>` tags. The new responsive _cardio_ site structure requires that we get an array of the style sheets so they can be rendered programmatically.

You can see this WIP here:
https://github.com/mdx-dev/vitals/blob/cardio/style_and_wrappers/app/twig_views/elements/head_logic/head_logic.twig#L16

In summary, what's changed:
- Updated `style` method
- Introduced `style_list` method
- Introduced `gen_css_files` method used by both
- Updated documentation throughout

Note: The changes have been discussed and reviewed by @blainesch.
